### PR TITLE
feat: add remote db support

### DIFF
--- a/train.py
+++ b/train.py
@@ -91,10 +91,7 @@ identifier = args.group if args.mode == "group" else args.id
 
 # 1. 数据提取
 print("正在提取数据...")
-if args.remote:
-    chat_df = extract_chat_data(args.db, identifier, mode=args.mode, remote=True)
-else:
-    chat_df = extract_chat_data(args.db, identifier, mode=args.mode, remote=False)
+chat_df = extract_chat_data(args.db, identifier, args.mode, args.remote)
 if chat_df.empty:
     print("[ERROR] 未提取到数据，程序退出。")
     exit(1)


### PR DESCRIPTION
## Summary
- extend `extract_chat_data` with `remote` option to connect to PostgreSQL via SQLAlchemy or default SQLite
- validate chat mode input and provide clear error messaging
- update training pipeline to use new `remote` argument

## Testing
- `python -m py_compile extract_chat_data.py train.py`
- `pip install pandas sqlalchemy` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_689b817b84fc8332b82f5d1f6c836c42